### PR TITLE
Add Material You support

### DIFF
--- a/app/src/main/java/com/readrops/app/more/preferences/PreferencesScreen.kt
+++ b/app/src/main/java/com/readrops/app/more/preferences/PreferencesScreen.kt
@@ -116,6 +116,7 @@ class PreferencesScreen : AndroidScreen() {
                                 entries = mapOf(
                                     "readrops" to stringResource(id = R.string.theme_readrops),
                                     "blackwhite" to stringResource(id = R.string.theme_blackwhite),
+				    "material3" to stringResource(id = R.string.theme_material3),
                                 ),
                                 title = stringResource(id = R.string.theme_color_scheme),
                                 onValueChange = {}

--- a/app/src/main/java/com/readrops/app/util/theme/Theme.kt
+++ b/app/src/main/java/com/readrops/app/util/theme/Theme.kt
@@ -4,6 +4,9 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.runtime.Composable
 
 private val lightScheme = lightColorScheme(
@@ -173,7 +176,14 @@ fun ReadropsTheme(
             } else {
                 BlackWhiteDarkScheme
             }
-        } else -> {
+        }
+	"material3" -> {
+	    if (!useDarkTheme) {
+		dynamicLightColorScheme(LocalContext.current)
+	    } else {
+		dynamicDarkColorScheme(LocalContext.current)
+	    }
+	} else -> {
             if (!useDarkTheme) {
                 lightScheme
             } else {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -27,6 +27,7 @@
     <string name="theme_color_scheme">Farbschema</string>
     <string name="theme_readrops">Readrops</string>
     <string name="theme_blackwhite">BlackWhite</string>
+    <string name="theme_material3">Material You</string>
     <string name="share_image">Bild teilen</string>
     <string name="download_image">Bild herunterladen</string>
     <string name="image_options">Bildoptionen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -74,7 +74,8 @@
     <string name="theme">Tema</string>
     <string name="theme_color_scheme">Bandera</string>
     <string name="theme_readrops">Readrops</string>
-    <string name="theme_blackwhite">BlackWhite</string>
+    <string name="theme_blackwhite">Blanco y Negro</string>
+    <string name="theme_material3">Material You</string>
     <string name="hour_1">1 hora</string>
     <string name="hour_6">6 horas</string>
     <string name="enable_auto_synchro_text">Para que se muestren, las notificaciones necesitan que la sincronización en segundo plano esté activada.

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -70,6 +70,7 @@
     <string name="theme_color_scheme">Schéma de couleurs</string>
     <string name="theme_readrops">Readrops</string>
     <string name="theme_blackwhite">BlackWhite</string>
+    <string name="theme_material3">Material You</string>
     <string name="light">Clair</string>
     <string name="dark">Sombre</string>
     <string name="new_feed">Nouveau flux</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -71,6 +71,7 @@
     <string name="theme_color_scheme">Skema Warna</string>
     <string name="theme_readrops">Readrops</string>
     <string name="theme_blackwhite">BlackWhite</string>
+    <string name="theme_material3">Material You</string>
     <string name="light">Terang</string>
     <string name="dark">Gelap</string>
     <string name="new_feed">Feed baru</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -28,6 +28,7 @@
     <string name="theme_color_scheme">Combinazione di colori</string>
     <string name="theme_readrops">Readrops</string>
     <string name="theme_blackwhite">BlackWhite</string>
+    <string name="theme_material3">Material You</string>
     <string name="share_image">Condividi l\'immagine</string>
     <string name="download_image">Scarica l\'immagine</string>
     <string name="image_options">Opzioni dell\'immagine</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -9,6 +9,7 @@
     <string name="theme_color_scheme">Fargevalg</string>
     <string name="theme_readrops">Readrops</string>
     <string name="theme_blackwhite">BlackWhite</string>
+    <string name="theme_material3">Material You</string>
     <string name="share_image">Del bilde</string>
     <string name="download_image">Last ned bilde</string>
     <string name="image_options">Bildevalg</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -64,6 +64,7 @@
     <string name="theme_color_scheme">Kleurenschema</string>
     <string name="theme_readrops">Readrops</string>
     <string name="theme_blackwhite">BlackWhite</string>
+    <string name="theme_material3">Material You</string>
     <string name="opml_import">Opml-bestand importeren</string>
     <string name="opml_export">Opml-bestand exporteren</string>
     <string name="image_options">Afbeeldingsopties</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -37,6 +37,7 @@
     <string name="theme_color_scheme">Esquema de cores</string>
     <string name="theme_readrops">Readrops</string>
     <string name="theme_blackwhite">BlackWhite</string>
+    <string name="theme_material3">Material You</string>
     <string name="light">Claro</string>
     <string name="dark">Escuro</string>
     <string name="new_feed">Novo Feed</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,6 +74,7 @@
     <string name="theme_color_scheme">Color Scheme</string>
     <string name="theme_readrops">Readrops</string>
     <string name="theme_blackwhite">BlackWhite</string>
+    <string name="theme_material3">Material You</string>
     <string name="light">Light</string>
     <string name="dark">Dark</string>
     <string name="new_feed">New feed</string>


### PR DESCRIPTION
This PR adds support for the Material You theme Android generates using Monet.

It still requires a way to disable the option when your version of Android doesn't support Material You, but I couldn't find a way to do it.

It also adds the translation of the Black and White Scheme's string to Spanish.